### PR TITLE
submission

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,25 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+    public UUID getId() {
+        return this.id;
+    }
+    public String getTitle() {
+        return this.title;
+    }
+    public String getAuthor() {
+        return this.author;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +56,9 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,6 +19,25 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    public void setRating(String rating) {
+        this.rating = rating;
+    }
+    public UUID getId() {
+        return this.id;
+    }
+    public String getTitle() {
+        return this.title;
+    }
+    public String getRating() {
+        return this.rating;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -37,11 +56,9 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -7,11 +7,23 @@ public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
         // quiz
+        BookFiction a = new BookFiction("old title", "old author", "old genre");
+        BookFiction b = new BookFiction("old title", "old author", "old genre");
+        b.setId(a.getId());
+        b.setAuthor("new author");
+        b.setTitle("new title");
+        assertTrue(a.equals(b));
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        MovieAction a = new MovieAction("old rating", "old rating");
+        MovieAction b = new MovieAction("old rating", "old rating");
+        b.setId(a.getId());
+        b.setRating("new rating");
+        b.setTitle("new title");
+        assertTrue(a.equals(b));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The bug can still pass with the given tests because none of the tests independently change the variables and keep the id the same. This is because there are no setters and getters to independently change other parameters for the Movie/Book object. The equals() function is also wrong because it should only be comparing the id's of each object and not the other parameters.